### PR TITLE
Update subscription message to stay under single message SMS limit

### DIFF
--- a/app/Http/Controllers/TwilioController.php
+++ b/app/Http/Controllers/TwilioController.php
@@ -65,7 +65,7 @@ class TwilioController extends Controller
                     $subscriber->subscribed = true;
                     $subscriber->save();
                 }
-                $returnMessage = 'Thanks for subscribing! Text STOP to unsubscribe. If you are not already registered to vote, go to https://bit.ly/voteictregister to do it now, right from your phone!';
+                $returnMessage = 'Thanks for subscribing! Text STOP to unsubscribe. Need to register to vote? Go to https://bit.ly/voteictregister to do it now, right from your phone!';
             }
         }
 


### PR DESCRIPTION
The previous message was 166 characters long. If sent as an SMS, Twilio will break the message and send one message with 153 characters and a second message with 13 characters. Modern phones will usually concatenate them correctly, but Twilio will charge for 2 messages sent for each time this is sent.

Here is Twilio's link to test how your message will be organized:
https://chadselph.github.io/smssplit/

**How the old message would send**
Message 1: "Thanks for subscribing! Text STOP to unsubscribe. If you are not already registered to vote, go to https://bit.ly/voteictregister to do it now, right fro"
Message 2: "m your phone!"