### PR TITLE
Add vCard link to homepage

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -17,7 +17,6 @@
         <div class="col-md-12 my-5">
             <h1 class="text-center">@lang('home.text_subscribe_cta')</h1>
             <h2 class="text-center">
-                <!-- TODO: make this a vcard link -->
                 @lang('home.add_to_contacts_cta', ['link' => 'tel:+1' . env('TWILIO_FROM_NUMBER')])
             </h2>
         </div>

--- a/resources/views/vcard.blade.php
+++ b/resources/views/vcard.blade.php
@@ -1,0 +1,7 @@
+BEGIN:VCARD
+VERSION:2.1
+N:{{ implode(';', array_reverse(explode(' ', config('app.name'), 2))) }};;;
+ORG:{{ config('app.name') }}
+TEL:+1{{ env('TWILIO_FROM_NUMBER') }}
+URL:{{ config('app.url') }}
+END:VCARD

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,12 @@
 
 Route::get('/', 'HomeController@index')->name('home');
 
+Route::get('/vcard', function () {
+    return response()->view('vcard')
+        ->header('Content-Type', 'text/vcard; charset=UTF-8')
+        ->header('Content-Disposition', 'attachment; filename=' . str_slug(config('app.name')) . '.vcf;');
+})->name('vcard');
+
 Auth::routes();
 
 // TODO: use a middleware to verify requests from Twilio


### PR DESCRIPTION
Fixes issue #7. This imports into Apple Contacts just fine, but might need to be tested on other platforms. According to this [Wikipedia article](https://en.wikipedia.org/wiki/VCard) `FN` is a required field. I've added `ORG` so that the contact info is treated as an organization instead of a person.