### PR TITLE
Move testing database into memory

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -1,15 +1,12 @@
+APP_ENV=testing
 APP_KEY=base64:lhd4fQ62Mk64yHUUCZxCaJWcEPNtVN0vOM+9o8M8bRE=
 APP_DEBUG=true
 APP_URL=http://homestead.test
 
 LOG_CHANNEL=none
 
-DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_DATABASE=homestead_testing
-DB_USERNAME=homestead
-DB_PASSWORD=secret
+DB_CONNECTION=sqlite
+DB_DATABASE=:memory:
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=array

--- a/database/migrations/2018_06_29_203948_add_incoming_bool_to_messages.php
+++ b/database/migrations/2018_06_29_203948_add_incoming_bool_to_messages.php
@@ -14,7 +14,10 @@ class AddIncomingBoolToMessages extends Migration
     public function up()
     {
         Schema::table('messages', function (Blueprint $table) {
-            $table->boolean('incoming')->after('twilio_sid');
+            $column = $table->boolean('incoming')->after('twilio_sid');
+            if (config('database.default') === 'sqlite') {
+                $column->default('');
+            }
         });
     }
 


### PR DESCRIPTION
This makes running tests really simple because you don't have to bother with setting up another database. There are some caveats though:

SQLite requires a default value when adding `NOT NULL` columns
SQLite doesn't support some of the fancier MySQL functions like `CONCAT`